### PR TITLE
Create a temporary directory with File::Temp

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ my %prereq =
   , File::Compare    => 0
   , File::Copy       => 0
   , File::Spec       => 0
+  , File::Temp       => 0.19
   , IO::Socket::IP   => 0
   , List::Util       => 0
   , Mail::IMAPClient => 3.42

--- a/t/21server-list.t
+++ b/t/21server-list.t
@@ -6,7 +6,7 @@
 use strict;
 use warnings;
 
-use Mail::Box::Test;
+use File::Temp 0.19 ();
 use Mail::Box::MH;
 use Mail::Box::Identity;
 use Mail::Server::IMAP4::List;
@@ -32,9 +32,7 @@ my @boxes =
 
 # Create the directory hierarchy
 
-my $top = '60imap-test';
-clean_dir($top);
-mkdir $top or die "$top: $!";
+my $top = File::Temp->newdir();
 
 foreach my $box (@boxes)
 {   my $dir = "$top/$box";
@@ -271,4 +269,3 @@ is(str($imap->list('/usr/staff/jones', '')), <<'__DELIM');
 (\Noselect) "/" /
 __DELIM
 
-clean_dir($top);


### PR DESCRIPTION
t/21server-list.t fails if run from a read-only location. The reason is that it attempts to create a temporary directory in a current working directory.

This patch fixes it by using File::Temp. That core Perl module utilizes a location dedicated for temporary files which is usually writable. That module also simplifies cleaning the directory.