### PR TITLE
Get peer host and port from Socket object, not IMAPClient

### DIFF
--- a/lib/Mail/Box/IMAP4.pm
+++ b/lib/Mail/Box/IMAP4.pm
@@ -182,8 +182,8 @@ sub init($)
 	$args->{message_type} ||= 'Mail::Box::IMAP4::Message';
 
     if(my $client = $args->{imap_client}) {
-       $args->{server_name} = $client->PeerAddr;
-       $args->{server_port} = $client->PeerPort;
+       $args->{server_name} = $client->Socket->peerhost();
+       $args->{server_port} = $client->Socket->peerport();
        $args->{username}    = $client->User;
     }
 


### PR DESCRIPTION
If the user specifies their own `Mail::IMAPClient` object when creating a `Mail::Box::IMAP4` object, then `Mail::Box::IMAP4` should get the host and port name of the connection from the `IMAPClient`'s `Socket` rather than trying to get them from the `IMAPClient` itself, where they don't exist.